### PR TITLE
Fix JNI types according to FreeType documentation

### DIFF
--- a/mathdisplaylib/src/main/cpp/freetype_jni.cpp
+++ b/mathdisplaylib/src/main/cpp/freetype_jni.cpp
@@ -324,7 +324,7 @@ Java_com_pvporbit_freetype_FreeType_FT_1GlyphSlot_1Get_1advance(JNIEnv *env, jcl
     FT_Vector vector = ((FT_GlyphSlot) glyph)->advance;
 
     jclass cls = env->FindClass("com/pvporbit/freetype/GlyphSlot$Advance");
-    jmethodID methodID = env->GetMethodID(cls, "<init>", "(II)V");
+    jmethodID methodID = env->GetMethodID(cls, "<init>", "(JJ)V");
     jobject a = env->NewObject(cls, methodID, (jlong) vector.x, (jlong) vector.y);
     return a;
 }

--- a/mathdisplaylib/src/main/java/com/agog/mathdisplay/render/MTFontMathTable.kt
+++ b/mathdisplaylib/src/main/java/com/agog/mathdisplay/render/MTFontMathTable.kt
@@ -204,6 +204,10 @@ class MTFontMathTable(val font: MTFont, var istreamotf: InputStream?) {
         return enclosing
     }
 
+    private fun fontUnitsToPt(fontUnits: Long): Float {
+        return fontUnits * fontSize / unitsPerEm
+    }
+
     private fun fontUnitsToPt(fontUnits: Int): Float {
         return fontUnits * fontSize / unitsPerEm
     }

--- a/mathdisplaylib/src/main/java/com/pvporbit/freetype/GlyphSlot.java
+++ b/mathdisplaylib/src/main/java/com/pvporbit/freetype/GlyphSlot.java
@@ -53,18 +53,18 @@ public class GlyphSlot extends Pointer {
 
     public static class Advance {
 
-        private final int x, y;
+        private final long x, y;
 
-        public Advance(int x, int y) {
+        public Advance(long x, long y) {
             this.x = x;
             this.y = y;
         }
 
-        public int getX() {
+        public long getX() {
             return x;
         }
 
-        public int getY() {
+        public long getY() {
             return y;
         }
 


### PR DESCRIPTION
`Advance` should be a tuple of type `long`, not `int`. This can affect certain devices, making the advance width/height `0`.

I do not currently have access to a problematic device so I cannot verify that this patch addresses the issue. However, it should close #6.

Glyph "advance" is used in the library as a field in `GlyphSlot`. [According to FreeType](https://www.freetype.org/freetype2/docs/reference/ft2-base_interface.html#ft_glyphslotrec) the `advance` field is of type `FT_Vector`. This [basic data type](https://www.freetype.org/freetype2/docs/reference/ft2-basic_types.html#ft_vector) is composed of two `long` values.

The fix involves:
 1. updating the JNI hook to use `(JJ)V` as the signature for `GlyphSlot$Advance`
 2. updating the fields in the Java class `Advance` to be of type `long`
 3. adding a helper function to handle the new `long` types in MTFontMathTable

I hope this helps!!
