### PR TITLE
Add support for textcolor

### DIFF
--- a/mathdisplaylib/src/main/java/com/agog/mathdisplay/parse/MTMathAtom.kt
+++ b/mathdisplaylib/src/main/java/com/agog/mathdisplay/parse/MTMathAtom.kt
@@ -62,6 +62,7 @@ enum class MTMathAtomType {
     /// Denotes style changes during rendering.
     KMTMathAtomStyle,
     KMTMathAtomColor,
+    KMTMathAtomTextColor,
 
     // Atoms after this point are not part of TeX and do not have the usual structure.
 
@@ -258,6 +259,9 @@ open class MTMathAtom(var type: MTMathAtomType, var nucleus: String) {
                 }
                 MTMathAtomType.KMTMathAtomColor -> {
                     return ("Color")
+                }
+                MTMathAtomType.KMTMathAtomTextColor -> {
+                    return ("TextColor")
                 }
                 MTMathAtomType.KMTMathAtomTable -> {
                     return ("Table")
@@ -862,3 +866,36 @@ class MTMathColor : MTMathAtom(MTMathAtomType.KMTMathAtomColor, "") {
 }
 
 
+// Colors are always KMTMathAtomColor type with a string for the color
+class MTMathTextColor : MTMathAtom(MTMathAtomType.KMTMathAtomTextColor, "") {
+
+
+    /// The inner math list
+    var innerList: MTMathList? = null
+    var colorString: String? = null
+
+
+    override fun toLatexString(): String {
+        var str = "\\textcolor"
+
+        str += "{$this.colorString}{$this.innerList}"
+
+        return super.toStringSubs(str)
+    }
+
+    override fun copyDeep(): MTMathTextColor {
+        val atom = MTMathTextColor()
+        super.copyDeepContent(atom)
+        atom.innerList = this.innerList?.copyDeep()
+        atom.colorString = this.colorString
+        return atom
+    }
+
+    override fun finalized(): MTMathTextColor {
+        val newColor: MTMathTextColor = this.copyDeep()
+        super.finalized(newColor)
+        newColor.innerList = newColor.innerList?.finalized()
+        return newColor
+    }
+
+}

--- a/mathdisplaylib/src/main/java/com/agog/mathdisplay/parse/MTMathListBuilder.kt
+++ b/mathdisplaylib/src/main/java/com/agog/mathdisplay/parse/MTMathListBuilder.kt
@@ -473,6 +473,13 @@ class MTMathListBuilder(str: String) {
                 mathColor.innerList = this.buildInternal(true)
                 return mathColor
             }
+            "textcolor" -> {
+                // A textcolor command has 2 arguments
+                val mathColor = MTMathTextColor()
+                mathColor.colorString = this.readColor()
+                mathColor.innerList = this.buildInternal(true)
+                return mathColor
+            }
             else -> {
                 this.setError(MTParseErrors.InvalidCommand, "Invalid command $command")
                 return null

--- a/mathdisplaylib/src/main/java/com/agog/mathdisplay/render/MTSpacing.kt
+++ b/mathdisplaylib/src/main/java/com/agog/mathdisplay/render/MTSpacing.kt
@@ -35,7 +35,7 @@ val interElementSpaceArray: Array<Array<MTInterElementSpaceType>> = arrayOf(
 fun getInterElementSpaceArrayIndexForType(type: MTMathAtomType, row: Boolean): Int {
     when (type) {
     // A placeholder is treated as ordinary
-        MTMathAtomType.KMTMathAtomColor, MTMathAtomType.KMTMathAtomOrdinary, MTMathAtomType.KMTMathAtomPlaceholder -> return 0
+        MTMathAtomType.KMTMathAtomColor, MTMathAtomType.KMTMathAtomTextColor, MTMathAtomType.KMTMathAtomOrdinary, MTMathAtomType.KMTMathAtomPlaceholder -> return 0
         MTMathAtomType.KMTMathAtomLargeOperator -> return 1
         MTMathAtomType.KMTMathAtomBinaryOperator -> return 2
         MTMathAtomType.KMTMathAtomRelation -> return 3

--- a/mathdisplaylib/src/main/java/com/agog/mathdisplay/render/MTTypesetter.kt
+++ b/mathdisplaylib/src/main/java/com/agog/mathdisplay/render/MTTypesetter.kt
@@ -178,6 +178,43 @@ class MTTypesetter(val font: MTFont, linestyle: MTLineStyle, var cramped: Boolea
                     }
                 }
 
+                KMTMathAtomTextColor -> {
+                    // stash the existing layout
+                    if (currentLine.isNotEmpty()) {
+                        this.addDisplayLine()
+                    }
+                    val colorAtom = atom as MTMathTextColor
+                    if (colorAtom.innerList != null) {
+                        val display = createLineForMathList(colorAtom.innerList!!, font, style)
+                        display.localTextColor = Color.parseColor(colorAtom.colorString)
+
+                        if (prevNode != null) {
+                            val interElementSpace = this.getInterElementSpace(prevNode.type, (display.subDisplays!![0] as MTCTLineDisplay).atoms[0].type)
+                            if (currentLine.isNotEmpty()) {
+                                if (interElementSpace > 0) {
+                                    //throw MathDisplayException("Kerning not handled")
+                                    // add a kerning of that space to the previous character
+                                    /*
+                                    [_currentLine addAttribute:(NSString*) kCTKernAttributeName
+                                            value:[NSNumber numberWithFloat:interElementSpace]
+                                    range:[_currentLine.string rangeOfComposedCharacterSequenceAtIndex:_currentLine.length - 1]]
+                                    */
+                                    // We are drawing a char at a time on Android. So same as single char case
+                                    currentPosition.x += interElementSpace
+                                }
+                            } else {
+                                // increase the space
+                                currentPosition.x += interElementSpace
+                            }
+                        }
+
+                        display.position = currentPosition
+                        currentPosition.x += display.width
+
+                        displayAtoms.add(display)
+                    }
+                }
+
                 KMTMathAtomRadical -> {
                     // stash the existing layout
                     if (currentLine.isNotEmpty()) {


### PR DESCRIPTION
`\color` has a alignment issue as seen with the following

```
a+b+c-d-e
\color{#ff3399}{a}+b+\color{#ff3399}{c}-d-\color{#ff3399}{e}
```

This adds a new atom, `\textcolor`, that doesn't have this issue:

```
\textcolor{#ff3399}{a}+b+\textcolor{#ff3399}{c}-d-\textcolor{#ff3399}{e}
```

The three above lines are rendered like this:

![image](https://github.com/gregcockroft/AndroidMath/assets/935414/02850799-5248-4029-b74c-9ec7af19d58d)

---

See https://github.com/mgriebling/SwiftMath/pull/16 for the SwiftMath version